### PR TITLE
December 2024 Release - Bump splunktaucclib (#45)

### DIFF
--- a/package/lib/requirements.txt
+++ b/package/lib/requirements.txt
@@ -1,5 +1,5 @@
 # Use built-in boto3 library
 #boto3==1.33.13
-splunktaucclib==6.5.0
+splunktaucclib==6.5.3
 pynacl==1.5.0
 cffi==1.15.1


### PR DESCRIPTION
Bumps the splunk group with 1 update in the /package/lib directory: splunktaucclib.


Updates `splunktaucclib` from 6.5.0 to 6.5.3

---
updated-dependencies:
- dependency-name: splunktaucclib dependency-type: direct:production update-type: version-update:semver-patch dependency-group: splunk ...