### PR TITLE
ci(integration-test): stop leaking 1Password secrets in Actions logs

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -21,6 +21,8 @@ permissions:
 
 jobs:
   integration-test:
+    # Secrets are not (and must not be) available to dependabot-triggered runs
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     
@@ -67,24 +69,34 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
         run: |
           source scripts/get_secrets_from_1password.sh
-          echo "SPLUNKCLOUD_STACK_URL=${SPLUNKCLOUD_STACK_URL}" >> $GITHUB_ENV
-          echo "SPLUNKCLOUD_ADMIN_USER=${SPLUNKCLOUD_ADMIN_USER}" >> $GITHUB_ENV
-          echo "SPLUNKCLOUD_ADMIN_PASSWORD=${SPLUNKCLOUD_ADMIN_PASSWORD}" >> $GITHUB_ENV
-          echo "ACS_STACK=${ACS_STACK}" >> $GITHUB_ENV
-          echo "SPLUNKBASE_USERNAME=${SPLUNKBASE_USERNAME}" >> $GITHUB_ENV
-          echo "SPLUNKBASE_PASSWORD=${SPLUNKBASE_PASSWORD}" >> $GITHUB_ENV
-          echo "SPLUNKBASE_AUTH=${SPLUNKBASE_AUTH}" >> $GITHUB_ENV
-          [ -n "$GITHUB_TOKEN" ] && echo "GITHUB_TOKEN=${GITHUB_TOKEN}" >> $GITHUB_ENV
-          [ -n "$GITHUB_REPO" ] && echo "GITHUB_REPO=${GITHUB_REPO}" >> $GITHUB_ENV
-          [ -n "$GITLAB_TOKEN" ] && echo "GITLAB_TOKEN=${GITLAB_TOKEN}" >> $GITHUB_ENV
-          [ -n "$GITLAB_PROJECT_URL" ] && echo "GITLAB_PROJECT_URL=${GITLAB_PROJECT_URL}" >> $GITHUB_ENV
-          [ -n "$AWS_ACCESS_KEY_ID" ] && echo "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}" >> $GITHUB_ENV
-          [ -n "$AWS_SECRET_ACCESS_KEY" ] && echo "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}" >> $GITHUB_ENV
-          [ -n "$AWS_DEFAULT_REGION" ] && echo "AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION}" >> $GITHUB_ENV
-          [ -n "$AWS_SECRET_NAME" ] && echo "AWS_SECRET_NAME=${AWS_SECRET_NAME}" >> $GITHUB_ENV
-          [ -n "$OP_CONNECT_HOST" ] && echo "OP_CONNECT_HOST=${OP_CONNECT_HOST}" >> $GITHUB_ENV
-          [ -n "$OP_CONNECT_TOKEN" ] && echo "OP_CONNECT_TOKEN=${OP_CONNECT_TOKEN}" >> $GITHUB_ENV
-          echo "OP_SERVICE_ACCOUNT_TOKEN=${OP_SERVICE_ACCOUNT_TOKEN}" >> $GITHUB_ENV
+          # SECURITY: values loaded from 1Password are NOT auto-masked (unlike secrets.*).
+          # Register every secret with the runner so it is REDACTED in all subsequent logs —
+          # without this, each later step prints its resolved `env:` block in clear text.
+          for _s in SPLUNKCLOUD_ADMIN_PASSWORD SPLUNKBASE_PASSWORD SPLUNKBASE_AUTH \
+                    GITHUB_TOKEN GITLAB_TOKEN AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY \
+                    OP_CONNECT_TOKEN OP_SERVICE_ACCOUNT_TOKEN; do
+            [ -n "${!_s}" ] && echo "::add-mask::${!_s}"
+          done
+          # Persist to the job environment (now masked from here on).
+          _put() { [ -n "$2" ] && printf '%s=%s\n' "$1" "$2" >> "$GITHUB_ENV"; }
+          _put SPLUNKCLOUD_STACK_URL "$SPLUNKCLOUD_STACK_URL"
+          _put SPLUNKCLOUD_ADMIN_USER "$SPLUNKCLOUD_ADMIN_USER"
+          _put SPLUNKCLOUD_ADMIN_PASSWORD "$SPLUNKCLOUD_ADMIN_PASSWORD"
+          _put ACS_STACK "$ACS_STACK"
+          _put SPLUNKBASE_USERNAME "$SPLUNKBASE_USERNAME"
+          _put SPLUNKBASE_PASSWORD "$SPLUNKBASE_PASSWORD"
+          _put SPLUNKBASE_AUTH "$SPLUNKBASE_AUTH"
+          _put GITHUB_TOKEN "$GITHUB_TOKEN"
+          _put GITHUB_REPO "$GITHUB_REPO"
+          _put GITLAB_TOKEN "$GITLAB_TOKEN"
+          _put GITLAB_PROJECT_URL "$GITLAB_PROJECT_URL"
+          _put AWS_ACCESS_KEY_ID "$AWS_ACCESS_KEY_ID"
+          _put AWS_SECRET_ACCESS_KEY "$AWS_SECRET_ACCESS_KEY"
+          _put AWS_DEFAULT_REGION "$AWS_DEFAULT_REGION"
+          _put AWS_SECRET_NAME "$AWS_SECRET_NAME"
+          _put OP_CONNECT_HOST "$OP_CONNECT_HOST"
+          _put OP_CONNECT_TOKEN "$OP_CONNECT_TOKEN"
+          _put OP_SERVICE_ACCOUNT_TOKEN "$OP_SERVICE_ACCOUNT_TOKEN"
       
       - name: Build app
         run: |
@@ -227,16 +239,19 @@ jobs:
         run: |
           echo "## Integration Test Results" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
+          # Redact secret-looking fields (vended tokens etc.) before publishing to the
+          # public job summary. jq 'walk' is available on ubuntu-latest.
+          redact() { jq 'walk(if type == "object" then with_entries(if (.key | test("token|secret|password|key|sessionKey|auth";"i")) then .value = "***REDACTED***" else . end) else . end)' "$1" 2>/dev/null || echo '{"note":"output withheld (could not redact safely)"}'; }
           if [ -f token_results.json ]; then
-            echo "### Token Generation Results" >> $GITHUB_STEP_SUMMARY
+            echo "### Token Generation Results (secrets redacted)" >> $GITHUB_STEP_SUMMARY
             echo '```json' >> $GITHUB_STEP_SUMMARY
-            cat token_results.json >> $GITHUB_STEP_SUMMARY
+            redact token_results.json >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
           fi
           if [ -f validation_results.json ]; then
-            echo "### Token Validation Results" >> $GITHUB_STEP_SUMMARY
+            echo "### Token Validation Results (secrets redacted)" >> $GITHUB_STEP_SUMMARY
             echo '```json' >> $GITHUB_STEP_SUMMARY
-            cat validation_results.json >> $GITHUB_STEP_SUMMARY
+            redact validation_results.json >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
           fi
 


### PR DESCRIPTION
## The problem
The `Retrieve secrets from 1Password` step writes every secret to `$GITHUB_ENV` **unmasked**. Because values from 1Password aren't auto-masked (only `secrets.*` are), every later step prints its resolved `env:` block in clear text — so this **public** repo's Actions logs have been exposing the **Splunk Cloud admin password, Splunkbase password, GitLab token, and AWS access key/secret**.

## The fix
1. **Mask at source** — register every secret with `::add-mask::` the moment it's sourced, so the runner redacts it in all downstream logs.
2. **Redact the job summary** — the `Report results` step `cat`-ed raw token JSON (vended tokens) into the public step summary; now secret-looking fields are redacted first.
3. **Skip dependabot runs** — `if: github.actor != 'dependabot[bot]'` (those runs can't access the secrets and were permanently red anyway).
