### PR TITLE
fix(gendeploytoken): run custom command locally (local = true)

### DIFF
--- a/package/default/commands.conf
+++ b/package/default/commands.conf
@@ -6,4 +6,4 @@ filename = gendeploytoken.py
 #requires_srinfo = false
 python.version = python3
 is_risky = false
-#local=true
+local = true


### PR DESCRIPTION
After the namespace fix (#81) the command resolves, but dispatch returns `404 Action forbidden`. The command was missing `local = true` (it was commented out), so Splunk tried to distribute a custom command that makes REST/external calls onto the indexer tier — forbidden on Splunk Cloud. Pin it to the search head.