### PR TITLE
fix(commands.conf): declare python.required = 3.13 for gendeploytoken

### DIFF
--- a/package/default/commands.conf
+++ b/package/default/commands.conf
@@ -5,5 +5,6 @@ chunked = true
 filename = gendeploytoken.py
 #requires_srinfo = false
 python.version = python3
+python.required = 3.13
 is_risky = false
 local = true


### PR DESCRIPTION
AppInspect flagged a FUTURE_FAILURE: `Stanza [gendeploytoken] does not define python.required` (required for Python-script commands under the Python 3.13 migration). Add `python.required = 3.13` so the app stays cloud/future-AppInspect clean as Splunk moves off 3.9.