### PR TITLE
ci: install ACS CLI + fail loudly on upload (the app was never installing)

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -106,6 +106,14 @@ jobs:
         run: |
           make dist
       
+      - name: Install ACS CLI
+        run: |
+          ACS_VERSION="v2.23.0"
+          curl -sSfLo /tmp/acs.tgz "https://github.com/splunk/acs-cli/releases/download/${ACS_VERSION}/acs_${ACS_VERSION}_linux_amd64.tar.gz"
+          tar -xzf /tmp/acs.tgz -C /tmp
+          sudo install -m 0755 "$(find /tmp -maxdepth 2 -name acs -type f | head -1)" /usr/local/bin/acs
+          acs --version || acs version
+
       - name: Upload to Splunk Cloud via ACS
         env:
           ACS_STACK: ${{ env.ACS_STACK }}
@@ -119,10 +127,12 @@ jobs:
             -d "username=${SPLUNKCLOUD_ADMIN_USER}&password=${SPLUNKCLOUD_ADMIN_PASSWORD}" \
             | grep -oP '(?<=<sessionKey>)[^<]+')
           
-          export STACK_TOKEN=$ACS_TOKEN
-          scripts/acscli_upload.sh || {
-            echo "ACS upload failed, but continuing with tests"
-          }
+          # Mask the session token (derived at runtime, not from 1Password -> not auto-masked)
+          echo "::add-mask::${ACS_TOKEN}"
+          export STACK_TOKEN="$ACS_TOKEN"
+          export STACK_USERNAME="${SPLUNKCLOUD_ADMIN_USER}"
+          # Fail loudly: a swallowed failure here previously hid that the app never installed
+          scripts/acscli_upload.sh
       
       - name: Wait for app installation
         run: |


### PR DESCRIPTION
**Root cause of the whole 'Generate test tokens' saga:** the app was never installed. `acscli_upload.sh` exits at its `command -v acs` guard ('acs CLI not found') because no workflow step installs it — and `|| echo "...continuing"` swallowed the failure, so downstream steps ran against an empty stack (`gendeploytoken` -> 'Action forbidden' because the app namespace doesn't exist).

- Install `splunk/acs-cli` v2.23.0 (linux_amd64) before upload.
- Pass `STACK_USERNAME`; **mask** the runtime-derived session token (`set -x` was tracing it; not a 1Password secret so it wasn't auto-masked).
- Drop the failure-swallow so a real install failure fails the job.